### PR TITLE
Only require the lodash functions we need

### DIFF
--- a/lib/velocity-component.js
+++ b/lib/velocity-component.js
@@ -33,7 +33,11 @@ Methods:
    occurs).
 */
 
-var _ = require('lodash');
+var _ = {
+  isEqual: require('lodash/lang/isEqual'),
+  keys: require('lodash/object/keys'),
+  omit: require('lodash/object/omit'),
+};
 var React = require('react');
 var Velocity = require('velocity-animate');
 

--- a/lib/velocity-helpers.js
+++ b/lib/velocity-helpers.js
@@ -1,4 +1,6 @@
-var _ = require('lodash');
+var _ = {
+  isObject: require('lodash/lang/isObject'),
+};
 var Velocity = require('velocity-animate');
 require('velocity-animate/velocity.ui');
 

--- a/lib/velocity-transition-group.js
+++ b/lib/velocity-transition-group.js
@@ -32,7 +32,13 @@ Statics
 Inspired by https://gist.github.com/tkafka/0d94c6ec94297bb67091
 */
 
-var _ = require('lodash');
+var _ = {
+  each: require('lodash/collection/each'),
+  extend: require('lodash/object/extend'),
+  keys: require('lodash/object/keys'),
+  omit: require('lodash/object/omit'),
+  pluck: require('lodash/collection/pluck'),
+};
 var React = require('react/addons');
 var Velocity = require('velocity-animate');
 


### PR DESCRIPTION
Speculatively reducing the packaged footprint if tooling is not capable
of doing this on its own.
