### PR TITLE
Fixes setting styles in VelocityTransitionGroup

### DIFF
--- a/lib/velocity-transition-group.js
+++ b/lib/velocity-transition-group.js
@@ -253,7 +253,7 @@ var VelocityTransitionGroup = React.createClass({
     // cases that you need to support your static styles being visible on the element before
     // the animation begins. 
     if (style != null) {
-      _.each(style, function (key, value) {
+      _.each(style, function (value, key) {
         Velocity.hook(nodes, key, value);
       });
     }
@@ -296,7 +296,7 @@ var VelocityTransitionGroup = React.createClass({
     var opts = parsedAnimation.opts;
 
     if (style != null) {
-      _.each(style, function (key, value) {
+      _.each(style, function (value, key) {
         Velocity.hook(node, key, value);
       });
     }


### PR DESCRIPTION
Order of arguments in _.each callback was reversed, nothing was actually
being set.
