### PR TITLE
Require babel-core explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react": ">=0.13.0"
   },
   "devDependencies": {
+    "babel-core": "^5.8.25",
     "babel-loader": "^5.3.2",
     "css-loader": "^0.19.0",
     "react": "^0.13.3",


### PR DESCRIPTION
Removes the peerDependencies warning for the demo.