### PR TITLE
Server-side rendering compatibility

### DIFF
--- a/velocity-component.js
+++ b/velocity-component.js
@@ -39,7 +39,12 @@ var _ = {
   omit: require('lodash/object/omit'),
 };
 var React = require('react');
-var Velocity = require('velocity-animate');
+var Velocity;
+if (typeof window !== 'undefined') {
+  Velocity = require('velocity-animate');
+} else {
+  Velocity = function stubbedVelocity() {};
+}
 
 var VelocityComponent = React.createClass({
   displayName: 'VelocityComponent',

--- a/velocity-helpers.js
+++ b/velocity-helpers.js
@@ -3,7 +3,12 @@
 var _ = {
   isObject: require('lodash/lang/isObject'),
 };
-var Velocity = require('velocity-animate');
+var Velocity;
+if (typeof window !== 'undefined') {
+  Velocity = require('velocity-animate');
+} else {
+  Velocity = function stubbedVelocity() {};
+}
 
 var effectCounter = 0;
 

--- a/velocity-transition-group.js
+++ b/velocity-transition-group.js
@@ -40,7 +40,12 @@ var _ = {
   pluck: require('lodash/collection/pluck'),
 };
 var React = require('react/addons');
-var Velocity = require('velocity-animate');
+var Velocity;
+if (typeof window !== 'undefined') {
+  Velocity = require('velocity-animate');
+} else {
+  Velocity = function stubbedVelocity() {};
+}
 
 // Internal wrapper for the transitioned elements. Delegates all child lifecycle events to the
 // parent VelocityTransitionGroup so that it can co-ordinate animating all of the elements at once.
@@ -55,15 +60,21 @@ var VelocityTransitionGroupChild = React.createClass({
   },
 
   componentWillAppear: function (doneFn) {
-    this.props.willAppearFunc(React.findDOMNode(this), doneFn);
+    if (typeof window !== 'undefined') {
+      this.props.willAppearFunc(React.findDOMNode(this), doneFn);
+    }
   },
 
   componentWillEnter: function (doneFn) {
-    this.props.willEnterFunc(React.findDOMNode(this), doneFn);
+    if (typeof window !== 'undefined') {
+      this.props.willEnterFunc(React.findDOMNode(this), doneFn);
+    }
   },
 
   componentWillLeave: function (doneFn) {
-    this.props.willLeaveFunc(React.findDOMNode(this), doneFn);
+    if (typeof window !== 'undefined') {
+      this.props.willLeaveFunc(React.findDOMNode(this), doneFn);
+    }
   },
 
   render: function () {


### PR DESCRIPTION
Just skips all the DOM animation stuff when it's not available; not a solution to handle animations on the server.

* stub the `window`-dependent "react-animate" package
* skip the DOM-dependent component-lifecycle hooks