### PR TITLE
update README with actual helper name

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ for options like `stagger`, `reverse`, *&tc.*
 `disabledForTest`: Set this to true globally to turn off all custom animation logic. Instead, this
   component will behave like a vanilla TransitionGroup`.
 
-### `velocityHelper`
+### `velocityHelpers`
 
 #### `registerEffect`
 


### PR DESCRIPTION
The README lists the helper's name as `velocityHelper`, but in the code its `velocityHelpers`.

Just a quick fix :).