### PR TITLE
Fixes VelocityTransitionGroup for no "leave"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### v1.1.1 (2015-10-21):
+
+#### Bug fixes
+ * Fix for `VelocityTransitionGroup` not animating when no `leave` prop is set.
+ * Better detection of existing `Velocity` instances (thanks, @arush!).
+
 ### v1.1.0 (2015-10-08):
 
 Updated peerDependencies and requires to React 0.14.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 Read our [announcement blog post](https://fabric.io/blog/introducing-the-velocityreact-library) for
 details about why and how we built this.
 
-**Latest version:** 1.1.0 is updated to require React 0.14
+**Latest version:** v1.1.1 fixes a small bug with `VelocityTransitionGroup` when no `leave` is
+provided. *Note: v1.1.0 and later require React 0.14.*
 
 ## Running the demo
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "velocity-react",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React components to wrap Velocity animations",
   "main": "index.js",
   "scripts": {

--- a/velocity-transition-group.js
+++ b/velocity-transition-group.js
@@ -141,7 +141,7 @@ var VelocityTransitionGroup = React.createClass({
   },
 
   childWillEnter: function (node, doneFn) {
-    if (this._shortCircuitAnimation(doneFn)) return;
+    if (this._shortCircuitAnimation(this.props.enter, doneFn)) return;
 
     // By finishing a "leave" on the element, we put it in the right state to be animated in. Useful
     // if "leave" includes a rotation or something that we'd like to have as our starting point, for
@@ -161,7 +161,7 @@ var VelocityTransitionGroup = React.createClass({
   },
 
   childWillLeave: function (node, doneFn) {
-    if (this._shortCircuitAnimation(doneFn)) return;
+    if (this._shortCircuitAnimation(this.props.leave, doneFn)) return;
 
     this._leaving.push({
       node: node,
@@ -177,8 +177,8 @@ var VelocityTransitionGroup = React.createClass({
   //
   // Returns true if this did short circuit, false if lifecycle methods should continue with
   // their animations.
-  _shortCircuitAnimation: function (doneFn) {
-    if (document.hidden || (this._parseAnimationProp(this.props.leave).animation == null)) {
+  _shortCircuitAnimation: function (animationProp, doneFn) {
+    if (document.hidden || (this._parseAnimationProp(animationProp).animation == null)) {
       if (this.isMounted()) {
         doneFn();
       }


### PR DESCRIPTION
Refactor into "_shortCircuitAnimation" failed to account for difference
between enter and leave.

Updates everything for a v1.1.1 release.