### PR TITLE
use the existing instance of Velocity instead of requiring a new one

### DIFF
--- a/lib/velocity-animate-shim.js
+++ b/lib/velocity-animate-shim.js
@@ -3,7 +3,13 @@
 // that they'll render, rather than doing something clever like
 // statically rendering the end state of any provided animations.
 if (typeof window !== 'undefined') {
-  module.exports = require('velocity-animate');
+
+  // this is how velocity-ui finds the Velocity instance, so lets make sure we find the right instance
+  var g = (window.jQuery || window.Zepto || window);
+
+  // require Velocity if it doesn't already exist
+  module.exports = g.Velocity ? g.Velocity : require('velocity-animate');
+
 } else {
   var Velocity = function () {};
   Velocity.velocityReactServerShim = true;


### PR DESCRIPTION
without this, velocity-react was always requiring a new instance of velocity-animate, so require('velocity-animate/velocity-ui') was attaching to the wrong instance. This finds an existing instance the correct way (the same way velocity.ui.js does it)