### PR TITLE
Clarify documentation about VelocityComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ still at React 0.13, use v1.0.1 of this package. Other than dependencies, it is 
 
 ### `VelocityComponent`
 
-Component to add Velocity animations to one or more children. Wraps a single child without adding
+Component to add Velocity animations to one child. Wraps a single child without adding
 additional DOM nodes.
 
 #### Example


### PR DESCRIPTION
After trying a `VelocityComponent` with more than one child: 
```
<VelocityComponent animation={popAnimation} runOnMount={true}>
    <div>H</div>
    <div>I</div>
</VelocityComponent>
```
I received the following error `Warning: Failed propType: Invalid prop 'children' supplied to 'VelocityComponent', expected a single ReactElement. Check the render method of 'CardManager'.` I looked through the source code for `velocity-component.js` and the [comments on lines 146-148](https://github.com/twitter-fabric/velocity-react/blob/master/velocity-component.js#L146) seems to declare that there should only be one child rendered which doesn't seem to comply with the "Component to add Velocity animations to one **or more children**" part of the documentation.