### PR TITLE
Fix memory leaks

### DIFF
--- a/velocity-component.js
+++ b/velocity-component.js
@@ -144,6 +144,9 @@ var VelocityComponent = React.createClass({
     Velocity(this._getDOMTarget(), 'stop', true);
   },
 
+  // Velocity keeps extensive caches for all animated elements to minimize layout thrashing.
+  // This can cause a serious memory leak, keeping references to unmounted elements as well
+  // completion handlers and associated react objects. This crudely clears these references.
   _clearVelocityCache: function (target) {
     if (target.length) {
       forEach(target, this._clearVelocityCache)

--- a/velocity-component.js
+++ b/velocity-component.js
@@ -34,6 +34,7 @@ Methods:
 */
 
 var _ = {
+  forEach: require('lodash/collection/forEach'),
   isEqual: require('lodash/lang/isEqual'),
   keys: require('lodash/object/keys'),
   omit: require('lodash/object/omit'),
@@ -80,6 +81,7 @@ var VelocityComponent = React.createClass({
 
   componentWillUnmount: function () {
     this._stopAnimation();
+    this._clearVelocityCache(this._getDOMTarget());
   },
 
   // It's ok to call this externally! By default the animation will be queued up. Pass stop: true in
@@ -140,6 +142,14 @@ var VelocityComponent = React.createClass({
 
   _stopAnimation: function () {
     Velocity(this._getDOMTarget(), 'stop', true);
+  },
+
+  _clearVelocityCache: function (target) {
+    if (target.length) {
+      forEach(target, this._clearVelocityCache)
+    } else {
+      Velocity.Utilities.removeData(target, ['velocity', 'fxqueue']);
+    }
   },
 
   // This component does not include any DOM footprint of its own, so instead we return our

--- a/velocity-transition-group.js
+++ b/velocity-transition-group.js
@@ -90,6 +90,11 @@ var VelocityTransitionGroupChild = React.createClass({
     this.props.willLeaveFunc(ReactDOM.findDOMNode(this), doneFn);
   },
 
+  componentWillUnmount: function () {
+    // Clear references from velocity cache.
+    Velocity.Utilities.removeData(ReactDOM.findDOMNode(this), ['velocity', 'fxqueue']);
+  },
+
   render: function () {
     return React.Children.only(this.props.children);
   },


### PR DESCRIPTION
Without jQuery, velocity implements it's own `$.data()` utility which
stores element (animation) data in one big cache object.

Data in this cache is never cleared which is an issue because it keeps
references to all animated dom elements as well as whole React trees
through velocity-react's `complete` handler.

This commit crudely clears the most important velocity data when an
animated component is unmounted.

See julianshapiro/velocity#644

Otherwise, this leak causes constant crashes for non-trivial webapps on mobile devices.