### PR TITLE
Fix README typo: TransitionGroup`

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ for options like `stagger`, `reverse`, *&tc.*
 #### Statics
 
 `disabledForTest`: Set this to true globally to turn off all custom animation logic. Instead, this
-  component will behave like a vanilla TransitionGroup`.
+  component will behave like a vanilla `TransitionGroup`.
 
 ### `velocityHelpers`
 


### PR DESCRIPTION
Just missing the other backtick :wink: