### PR TITLE
use dot-notation for importing lodash utilities

### DIFF
--- a/velocity-component.js
+++ b/velocity-component.js
@@ -34,9 +34,9 @@ Methods:
 */
 
 var _ = {
-  isEqual: require('lodash/lang/isEqual'),
-  keys: require('lodash/object/keys'),
-  omit: require('lodash/object/omit'),
+  isEqual: require('lodash/lang').isEqual,
+  keys: require('lodash/object').keys,
+  omit: require('lodash/object').omit,
 };
 var React = require('react');
 var ReactDOM = require('react-dom');

--- a/velocity-helpers.js
+++ b/velocity-helpers.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015 Twitter, Inc. and other contributors
 
 var _ = {
-  isObject: require('lodash/lang/isObject'),
+  isObject: require('lodash/lang').isObject,
 };
 var Velocity = require('./lib/velocity-animate-shim');
 

--- a/velocity-transition-group.js
+++ b/velocity-transition-group.js
@@ -41,13 +41,13 @@ Inspired by https://gist.github.com/tkafka/0d94c6ec94297bb67091
 */
 
 var _ = {
-  each: require('lodash/collection/each'),
-  extend: require('lodash/object/extend'),
-  forEach: require('lodash/collection/forEach'),
-  isEqual: require('lodash/lang/isEqual'),
-  keys: require('lodash/object/keys'),
-  omit: require('lodash/object/omit'),
-  pluck: require('lodash/collection/pluck'),
+  each: require('lodash/collection').each,
+  extend: require('lodash/object').extend,
+  forEach: require('lodash/collection').forEach,
+  isEqual: require('lodash/lang').isEqual,
+  keys: require('lodash/object').keys,
+  omit: require('lodash/object').omit,
+  pluck: require('lodash/collection').pluck,
 };
 var React = require('react');
 var ReactDOM = require('react-dom');


### PR DESCRIPTION
I'm developing [a toolkit for React](https://github.com/stoikerty/dev-toolkit) that works as an npm-module, similar to [`create-react-app`](https://github.com/facebookincubator/create-react-app). For some reason I was getting an error related to velocity in one of the projects I'm working on:
```bash
ERROR in ./~/velocity-react/velocity-transition-group.js
Module not found: Error: Cannot resolve module 'lodash/collection/each' in /myproject/node_modules/velocity-react
 @ ./~/velocity-react/velocity-transition-group.js 44:8-41
```

I was getting the same type of error for all lodash imports, so I looked into the `lodash` folder under `npm_modules` and found out the package doesn't have the specified subfolders, at least not with my installation. I therefore made the change to include the utilities via dot-notation instead which made everything work flawlessly.