### PR TITLE
Bump velocity-animate to 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "lodash": "^3.10.1",
     "react-addons-transition-group": "^0.14.0 || ^15.0.0",
-    "velocity-animate": "^1.2.3"
+    "velocity-animate": "^1.3.1"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",


### PR DESCRIPTION
1.3.0 has no breaking changes according to their README (just code cleanup), and 1.3.1 contains a race condition fix for an error that we saw in production (https://github.com/julianshapiro/velocity/pull/690). 1.3.1 is the current latest version.