### PR TITLE
Release bump for 1.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v1.1.9 (2016-10-17):
+
+Bump `velocity-animate` to v1.3.1 (fixes https://github.com/julianshapiro/velocity/issues/305)
+
 ### v1.1.8 (2016-10-07):
 
 #### Bug fixes

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ details about why and how we built this.
 
 See the [live demo](http://twitter-fabric.github.io/velocity-react/).
 
-**Latest version:** v1.1.8 fixes IE compatibility, broken in 1.1.7. (Thanks, @stephenleicht)
+**Latest version:** v1.1.9 bumps `velocity-animate` to 1.3.1 (latest).
 
 *Note: v1.1.0 and later require React 0.14.*
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "velocity-react",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "React components to wrap Velocity animations",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Just doing a patch bump since 1.3.1 of `velocity-animate` doesn't have any breaking changes, just code cleanup and a few bug fixes.