### PR TITLE
Revert "Bump velocity-animate to 1.3.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "lodash": "^3.10.1",
     "react-addons-transition-group": "^0.14.0 || ^15.0.0",
-    "velocity-animate": "^1.3.1"
+    "velocity-animate": "^1.2.3"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",


### PR DESCRIPTION
Reverts twitter-fabric/velocity-react#135

1.3.1 isn't published to npm yet :(