### PR TITLE
Bump velocity-animate to 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "lodash": "^3.10.1",
     "react-addons-transition-group": "^0.14.0 || ^15.0.0",
-    "velocity-animate": "^1.2.3"
+    "velocity-animate": "^1.3.1"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",


### PR DESCRIPTION
Now that 1.3.1 is published to npm, we can do this.

Reverts twitter-fabric/velocity-react#137