### PR TITLE
Check for navigator before checking its properties.

### DIFF
--- a/lib/velocity-animate-shim.js
+++ b/lib/velocity-animate-shim.js
@@ -8,7 +8,7 @@
 // https://github.com/twitter-fabric/velocity-react/issues/119
 // but there may have been different loading issues in that case,
 // not a global incompatibility with jsdom.
-if (typeof window === 'undefined' || navigator.userAgent.indexOf("Node.js") !== -1 || navigator.userAgent.indexOf("jsdom") !== -1) {
+if (typeof window === 'undefined' || typeof navigator === 'undefined' || navigator.userAgent.indexOf("Node.js") !== -1 || navigator.userAgent.indexOf("jsdom") !== -1) {
 
   var Velocity = function() {};
   Velocity.Utilities = {};


### PR DESCRIPTION
Checking for `navigator` (in addition to window) allows for usage in webpack when rendering on the server.
