### PR TITLE
Fix peerDependencies to be compatible with the 'react-transition-group' package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "compile": "babel src --out-dir .",
-    "demo": "./node_modules/.bin/webpack-dev-server --progress --colors --content-base demo --hot --inline --config demo/webpack.config.js",
+    "demo": "webpack-dev-server --progress --colors --content-base demo --hot --inline --config demo/webpack.config.js",
     "prepublish": "npm run compile"
   },
   "repository": {
@@ -30,8 +30,8 @@
     "velocity-animate": "^1.4.0"
   },
   "peerDependencies": {
-    "react": "^0.14.9 || ^15.3.0 || ^16.0.0",
-    "react-dom": "^0.14.9 || ^15.3.0 || ^16.0.0"
+    "react": "^15.3.0 || ^16.0.0",
+    "react-dom": "^15.3.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
`react-transition-group` [requires](https://github.com/reactjs/react-transition-group/blob/master/package.json#L41-L42) `React ^15.0.0`