### PR TITLE
IE8's clearTimeout is not a function

### DIFF
--- a/src/velocity-transition-group.js
+++ b/src/velocity-transition-group.js
@@ -72,7 +72,7 @@ var shimCancelAnimationFrame =
     window.cancelAnimationFrame ||
     window.webkitCancelAnimationFrame ||
     window.mozCancelAnimationFrame ||
-    window.clearTimeout
+    function(timeout) { window.clearTimeout(timeout); }
   );
 
 shimCancelAnimationFrame = (typeof window !== 'undefined') && shimCancelAnimationFrame.bind(window);


### PR DESCRIPTION
IE8 throws "Object doesn't support this property or method" on shimCancelAnimationFrame.bind(window)